### PR TITLE
Syntax update compliance

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ const renderSchemaWithPartials = function (schema) {
       const extensions = getExtensions(item);
       delete extensions.using;
       const extensionList = Object.keys(extensions)
-        .map(extension => ' ' + extension + ' ' + extensions[extension].join(', '));
+        .map(extension => ' ' + extension + ' ' + extensions[extension].join(' & '));
 
       const name = item.name ? ' ' + item.name : '';
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git://github.com/sydsvenskan/node-graphql-partials"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "main": "index.js",
   "bin": {
@@ -20,7 +20,7 @@
     "update-examples": "./cli.js examples/with-partials.graphql > examples/without-partials.graphql",
     "mocha": "NODE_ENV=test istanbul cover _mocha -- -u exports -R spec test/**/*.spec.js",
     "dependency-check": "JS_FILES=\"*.js test/*/*.js\" && dependency-check . $JS_FILES && dependency-check . $JS_FILES --unused --no-dev",
-    "test": "npm run --silent build && installed-check -e && eslint --ext .js --ext .jsx . && npm run --silent dependency-check && npm run --silent mocha",
+    "test": "npm run --silent build && installed-check -e -i eslint && eslint --ext .js --ext .jsx . && npm run --silent dependency-check && npm run --silent mocha",
     "build": "pegjs schema-parser.pegjs > schema-parser.js",
     "watch": "nodemon -w schema-parser.pegjs -x \"npm run --silent build\"",
     "prepush": "npm test",
@@ -28,18 +28,18 @@
   },
   "devDependencies": {
     "chai": "^4.1.0",
-    "dependency-check": "^2.9.1",
-    "eslint": "^4.2.0",
-    "eslint-config-semistandard": "^11.0.0",
-    "eslint-config-standard": "^10.0.0",
+    "dependency-check": "^3.2.1",
+    "eslint": "^5.6.0",
+    "eslint-config-semistandard": "^12.0.1",
+    "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-node": "^5.1.0",
-    "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-standard": "^3.0.1",
-    "husky": "^0.14.3",
+    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0",
+    "husky": "^1.0.0",
     "installed-check": "^2.1.1",
     "istanbul": "^0.4.5",
-    "mocha": "^4.0.1",
+    "mocha": "^5.2.0",
     "nodemon": "^1.11.0",
     "pegjs": "^0.10.0"
   },

--- a/schema-parser.pegjs
+++ b/schema-parser.pegjs
@@ -12,26 +12,26 @@ TypeContent
   = [^}]* { return text(); }
 
 Extension
-  = _ type:String _ names:CommaSeparatedString {
+  = _ type:String _ names:AmpersandSeparatedString {
     return { type, names };
   }
 
 Implements
-  = _ "implements" _ interfaces:CommaSeparatedString { return interfaces; }
+  = _ "implements" _ interfaces:AmpersandSeparatedString { return interfaces; }
 
 Uses
-  = _ "using" _ traits:CommaSeparatedString { return traits; }
+  = _ "using" _ traits:AmpersandSeparatedString { return traits; }
 
 Comment
   = _? "#" comment:EverythingButNewline sp* nl { return comment.trim(); }
 
-CommaSeparatedString
-  = head:String tail:(CommaPrefixedString)* {
+AmpersandSeparatedString
+  = head:String tail:(AmpersandPrefixedString)* {
     return [head].concat(tail);
   }
 
-CommaPrefixedString
-  = _? "," _? value:String { return value; }
+AmpersandPrefixedString
+  = _? "&" _? value:String { return value; }
 
 SpacePrefixedString
   = _ value:String { return value; }

--- a/test/unit/main.spec.js
+++ b/test/unit/main.spec.js
@@ -25,7 +25,7 @@ interface ContentInterface using ContentFields {
 # Wow 😧 Is this real?
 # 🚀 Very much so!
 
-interface Document implements ContentInterface using FooFields, ContentFields {
+interface Document implements ContentInterface using FooFields & ContentFields {
   uuid: ID!
 }
 `;


### PR DESCRIPTION
[graphql-js 0.13.0](https://github.com/graphql/graphql-js/releases/v0.13.0) introduced [breaking syntax changes](https://github.com/graphql/graphql-js/pull/1169) by separating multiple inherited interfaces with ampersands instead of commas.

I have updated the AST parser to only accept this new format. The compiler will now also output the updated syntax.

Oh, and I took the liberty to update some dependencies and set node >= 8 as a requirement.