### PR TITLE
Descriptions as strings

### DIFF
--- a/examples/with-partials.graphql
+++ b/examples/with-partials.graphql
@@ -3,11 +3,11 @@ schema {
 }
 
 type Query {
-  # Fetch an individual document
+  "Fetch an individual document"
   document(
-    # The UUID of the document
+    "The UUID of the document"
     uuid: ID
-    # The URL path that the document is exposed to on the public site
+    "The URL path that the document is exposed to on the public site"
     path: String
   ): Document
 }
@@ -22,19 +22,19 @@ partial LinkFields {
 partial DocumentFields using LinkFields {
   uuid: ID!
 
-  # The document type, such as x-im/article
+  "The document type, such as x-im/article"
   type: String
-  # If specified, then a list of the products to which this document's availability is limited
+  "If specified, then a list of the products to which this document's availability is limited"
   products: [String]
-  # The human readable name of the document, often used publicly to identify the document
+  "The human readable name of the document, often used publicly to identify the document"
   title: String
 
-  # The specific path on the web page where this document is publicly available
+  "The specific path on the web page where this document is publicly available"
   path: String
 
-  # A single metadata block
+  "A single metadata block"
   metaBlock(
-    # The specific metadata block type to get
+    "The specific metadata block type to get"
     type: String
   ): MetadataBlock
 }
@@ -57,3 +57,4 @@ type MetadataBlock implements Block using BlockFields {}
 type Link implements Block using BlockFields {
   rel: String
 }
+

--- a/examples/with-partials.graphql
+++ b/examples/with-partials.graphql
@@ -54,7 +54,7 @@ interface Block using BlockFields {}
 
 type MetadataBlock implements Block using BlockFields {}
 
+"A reference to another document"
 type Link implements Block using BlockFields {
   rel: String
 }
-

--- a/examples/without-partials.graphql
+++ b/examples/without-partials.graphql
@@ -4,11 +4,11 @@ schema {
 }
 
 type Query {
-  # Fetch an individual document
+  "Fetch an individual document"
   document(
-    # The UUID of the document
+    "The UUID of the document"
     uuid: ID
-    # The URL path that the document is exposed to on the public site
+    "The URL path that the document is exposed to on the public site"
     path: String
   ): Document
 }
@@ -21,19 +21,19 @@ interface Document {
 
   uuid: ID!
 
-  # The document type, such as x-im/article
+  "The document type, such as x-im/article"
   type: String
-  # If specified, then a list of the products to which this document's availability is limited
+  "If specified, then a list of the products to which this document's availability is limited"
   products: [String]
-  # The human readable name of the document, often used publicly to identify the document
+  "The human readable name of the document, often used publicly to identify the document"
   title: String
 
-  # The specific path on the web page where this document is publicly available
+  "The specific path on the web page where this document is publicly available"
   path: String
 
-  # A single metadata block
+  "A single metadata block"
   metaBlock(
-    # The specific metadata block type to get
+    "The specific metadata block type to get"
     type: String
   ): MetadataBlock
 }
@@ -46,19 +46,19 @@ type AuthorDocument implements Document {
 
   uuid: ID!
 
-  # The document type, such as x-im/article
+  "The document type, such as x-im/article"
   type: String
-  # If specified, then a list of the products to which this document's availability is limited
+  "If specified, then a list of the products to which this document's availability is limited"
   products: [String]
-  # The human readable name of the document, often used publicly to identify the document
+  "The human readable name of the document, often used publicly to identify the document"
   title: String
 
-  # The specific path on the web page where this document is publicly available
+  "The specific path on the web page where this document is publicly available"
   path: String
 
-  # A single metadata block
+  "A single metadata block"
   metaBlock(
-    # The specific metadata block type to get
+    "The specific metadata block type to get"
     type: String
   ): MetadataBlock
 }
@@ -71,19 +71,19 @@ type SubjectDocument implements Document {
 
   uuid: ID!
 
-  # The document type, such as x-im/article
+  "The document type, such as x-im/article"
   type: String
-  # If specified, then a list of the products to which this document's availability is limited
+  "If specified, then a list of the products to which this document's availability is limited"
   products: [String]
-  # The human readable name of the document, often used publicly to identify the document
+  "The human readable name of the document, often used publicly to identify the document"
   title: String
 
-  # The specific path on the web page where this document is publicly available
+  "The specific path on the web page where this document is publicly available"
   path: String
 
-  # A single metadata block
+  "A single metadata block"
   metaBlock(
-    # The specific metadata block type to get
+    "The specific metadata block type to get"
     type: String
   ): MetadataBlock
 }
@@ -96,19 +96,19 @@ type ArticleDocument implements Document {
 
   uuid: ID!
 
-  # The document type, such as x-im/article
+  "The document type, such as x-im/article"
   type: String
-  # If specified, then a list of the products to which this document's availability is limited
+  "If specified, then a list of the products to which this document's availability is limited"
   products: [String]
-  # The human readable name of the document, often used publicly to identify the document
+  "The human readable name of the document, often used publicly to identify the document"
   title: String
 
-  # The specific path on the web page where this document is publicly available
+  "The specific path on the web page where this document is publicly available"
   path: String
 
-  # A single metadata block
+  "A single metadata block"
   metaBlock(
-    # The specific metadata block type to get
+    "The specific metadata block type to get"
     type: String
   ): MetadataBlock
 }

--- a/examples/without-partials.graphql
+++ b/examples/without-partials.graphql
@@ -133,6 +133,7 @@ type MetadataBlock implements Block {
   document: Document
 }
 
+"A reference to another document"
 type Link implements Block {
   links(
     rel: String

--- a/index.js
+++ b/index.js
@@ -50,14 +50,14 @@ const renderSchemaWithPartials = function (schema) {
   const parsedSchema = schemaParser.parse(schema);
 
   const partials = parsedSchema
-    .filter(item => typeof item === 'object' && item.type === 'partial' && item.name)
+    .filter(item => item.type === 'partial' && item.name)
     .reduce((map, item) => {
       map[item.name] = item;
       return map;
     }, {});
 
   parsedSchema.forEach(item => {
-    if (typeof item === 'string') { return; }
+    if (item.type === 'comment' || item.type === 'description') { return; }
 
     const extensions = getExtensions(item);
 
@@ -74,11 +74,14 @@ const renderSchemaWithPartials = function (schema) {
 
   return parsedSchema
     .map(item => {
-      if (typeof item === 'string') {
-        return '# ' + item;
+      switch (item.type) {
+        case 'partial':
+          return;
+        case 'description':
+          return `"${item.content}"`;
+        case 'comment':
+          return `# ${item.content}`;
       }
-
-      if (item.type === 'partial') { return; }
 
       const extensions = getExtensions(item);
       delete extensions.using;

--- a/schema-parser.pegjs
+++ b/schema-parser.pegjs
@@ -24,7 +24,7 @@ Uses
   = _ "using" _ traits:CommaSeparatedString { return traits; }
 
 SingleLineDescription
-  = _? '"' description:EverythingButNewline '"' sp* nl {
+  = _? '"' description:SingleLineString '"' sp* nl {
     return { type: 'description', content: description };
   }
 
@@ -46,6 +46,9 @@ SpacePrefixedString
 
 EverythingButNewline
   = (sp* [^\r\n])+ { return text().trim(); }
+
+SingleLineString
+  = (sp* [^\r\n\"])+ { return text(); }
 
 String "string"
   = [a-zA-Z0-9]+ { return text(); }

--- a/schema-parser.pegjs
+++ b/schema-parser.pegjs
@@ -1,11 +1,12 @@
 // Very simple schema parser
+// TODO: Add support for multiline descriptions
 
 Expression
-  = data:(Comment / Type)* _* { return data; }
+  = data:(SingleLineDescription / Comment / Type)* _* { return data; }
 
 Type
   = _? type:String name:SpacePrefixedString? extensions:Extension* _? "{" content:TypeContent "}" {
-    return { type,  name, extensions, content };
+    return { type, name, extensions, content };
   }
 
 TypeContent
@@ -22,8 +23,15 @@ Implements
 Uses
   = _ "using" _ traits:CommaSeparatedString { return traits; }
 
+SingleLineDescription
+  = _? '"' description:EverythingButNewline '"' sp* nl {
+    return { type: 'description', content: description };
+  }
+
 Comment
-  = _? "#" comment:EverythingButNewline sp* nl { return comment.trim(); }
+  = _? "#" comment:EverythingButNewline sp* nl {
+    return { type: 'comment', content: comment };
+  }
 
 CommaSeparatedString
   = head:String tail:(CommaPrefixedString)* {


### PR DESCRIPTION
In [graphql/graphql-js#927](https://github.com/graphql/graphql-js/pull/927) (v0.12.0) decription syntax changed from being synonymous with comments to being defined as strings.

This PR allows the use of single line descriptions as strings. I have not included multi line descriptions for now. We might consider adding it later.